### PR TITLE
Update Cargo.toml for client to add support for tls1.2 when use wss

### DIFF
--- a/vnt/Cargo.toml
+++ b/vnt/Cargo.toml
@@ -46,7 +46,7 @@ zstd = { version = "0.13.1", optional = true }
 fnv = "1.0.7"
 igd = { version = "0.12.1", optional = true }
 tokio-tungstenite = { version = "0.23.1", optional = true }
-rustls = { version = "0.23.0", features = ["ring"], default-features = false, optional = true }
+rustls = { version = "0.23.0", features = ["ring", "tls12"], default-features = false, optional = true }
 
 network-interface = "2.0.0"
 


### PR DESCRIPTION
修复 #170 。当rultls没有使用tls12特性构建时，vnt客户端使用wss连接服务器时，仅支持tls1.3加密套件。此时若wss反向代理不支持tls1.3，便会连接失败。通过添加tls12特性，vnt客户端使用wss连接服务器时，可以同时支持tls1.2和tls1.3。